### PR TITLE
Proxy fix

### DIFF
--- a/kubectl.go
+++ b/kubectl.go
@@ -29,7 +29,6 @@ import (
 // correct version of kubectl is used for the target cluster.
 
 var (
-	BinDir           = "/usr/bin"
 	DefaultMajorVers = "1"
 	DefaultMinorVers = "18"
 )
@@ -46,9 +45,6 @@ type Version struct {
 }
 
 func main() {
-	if str := os.Getenv("BINDIR"); str != "" {
-		BinDir = str
-	}
 	if str := os.Getenv("DEFAULT_MAJOR_VERS"); str != "" {
 		DefaultMajorVers = str
 	}
@@ -133,21 +129,24 @@ func main() {
 	}
 }
 
+func getBinDir() string {
+	return os.Getenv("HOME") + "/bin"
+}
+
 func kubectlPath(maj, min string) string {
-	return fmt.Sprintf("%s/kubectl-v%s.%s.0", BinDir, maj, min)
+	return fmt.Sprintf("%s/kubectl-v%s.%s.0", getBinDir(), maj, min)
 }
 
 func download(maj, min string) {
-	tmpKubectl := "/tmp/kubectl"
+	if err := os.MkdirAll(getBinDir(), 0755); err != nil {
+		log.Fatalf("mkdirp %s failed, %s", getBinDir(), err)
+	}
 	kubectl := kubectlPath(maj, min)
-	cmd := exec.Command("curl", "-sLf", "-o", tmpKubectl,
+	cmd := exec.Command("curl", "-sLf", "-o", kubectl,
 		"https://dl.k8s.io/release/v"+maj+"."+min+".0/bin/linux/amd64/kubectl")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Fatalf("%s: %s: %s", cmd.String(), string(out), err)
-	}
-	if err := os.Rename(tmpKubectl, kubectl); err != nil {
-		log.Fatalf("rename %s to %s failed, %s", tmpKubectl, kubectl, err)
 	}
 	if err := os.Chmod(kubectl, 0755); err != nil {
 		log.Fatalf("chmod %s to 0755 failed, %s", kubectl, err)

--- a/kubectl.go
+++ b/kubectl.go
@@ -138,16 +138,18 @@ func kubectlPath(maj, min string) string {
 }
 
 func download(maj, min string) {
+	tmpKubectl := "/tmp/kubectl"
 	kubectl := kubectlPath(maj, min)
-	cmd := exec.Command("sudo", "curl", "-sLf", "-o", kubectl,
+	cmd := exec.Command("curl", "-sLf", "-o", tmpKubectl,
 		"https://dl.k8s.io/release/v"+maj+"."+min+".0/bin/linux/amd64/kubectl")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Fatalf("%s: %s: %s", cmd.String(), string(out), err)
 	}
-	chmodCmd := exec.Command("sudo", "chmod", "0755", kubectl)
-	out, err = chmodCmd.CombinedOutput()
-	if err != nil {
-		log.Fatalf("%s: %s: %s", cmd.String(), string(out), err)
+	if err := os.Rename(tmpKubectl, kubectl); err != nil {
+		log.Fatalf("rename %s to %s failed, %s", tmpKubectl, kubectl, err)
+	}
+	if err := os.Chmod(kubectl, 0755); err != nil {
+		log.Fatalf("chmod %s to 0755 failed, %s", kubectl, err)
 	}
 }


### PR DESCRIPTION
When proxy env vars are set, using 'sudo' as part of the curl command ends up dropping the proxy env vars, causing the curl request to fail.

This changes the location of the kubectls so that we don't need sudo perms, so curl can inherit the proxy env vars. Note this will also allow the command to be run without sudo perms at all.